### PR TITLE
require pycddlib<3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 matplotlib
 ortools
 lark-parser
-pycddlib
+pycddlib < 3.0.0
 graphviz
 torch
 psitip == 1.1.6


### PR DESCRIPTION
Pycddlib is getting a big revamp to properly support type hints, and as a result the API is going to change quite a bit. To prevent users installing your package to experience problems, I suggest explicitly specifying pycddlib<3.0.0 in dependencies now, prior to pycddlib getting its new release out of beta, until the project has migrated to the new pycddlib API.

More info here: https://pycddlib.readthedocs.io/en/latest/changes.html